### PR TITLE
Fix wrong directory fields

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,12 @@ RUN BUILD_DEPS="build-base openssl-dev libffi-dev python-dev git py-virtualenv p
  && apk del $BUILD_DEPS \
  && rm -r "$HOME/.cache/pip/"
 
+# Bump the ACME dep to 0.6.0 (simp_le normally references 0.5.0) to get
+# https://github.com/certbot/certbot/pull/2963. This ensures we can renew ACME
+# certificates even when new fields that our version of the library doesn't
+# understand are introduced.
+RUN "${SIMPLE_LE_DIR}/venv/bin/pip" install acme==0.6.0
+
 ENV PATH $SIMPLE_LE_DIR/venv/bin:$PATH
 ADD bin/acme-acquire-cert $SIMPLE_LE_DIR/venv/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ push: build
 	set -e ; \
 	for registry in $(PUSH_REGISTRIES); do \
 		for tag in $(PUSH_TAGS); do \
-			docker tag -f "$(REGISTRY)/$(REPOSITORY):$(TAG)" "$${registry}/$(REPOSITORY):$${tag}"; \
+			docker tag "$(REGISTRY)/$(REPOSITORY):$(TAG)" "$${registry}/$(REPOSITORY):$${tag}"; \
 			docker push "$${registry}/$(REPOSITORY):$${tag}"; \
 		done \
 	done
@@ -88,7 +88,7 @@ test: build
 build: $(TAG)/Dockerfile
 	docker build -t "$(REGISTRY)/$(REPOSITORY):$(TAG)" -f "$(TAG)/Dockerfile" .
 ifeq "$(TAG)" "$(LATEST_TAG)"
-	docker tag -f "$(REGISTRY)/$(REPOSITORY):$(TAG)" "$(REGISTRY)/$(REPOSITORY):latest"
+	docker tag "$(REGISTRY)/$(REPOSITORY):$(TAG)" "$(REGISTRY)/$(REPOSITORY):latest"
 endif
 
 


### PR DESCRIPTION
Bump acme library to 0.6.0

Our authorizations are otherwise failing because we're unable to
understand a new `key-change` ACME method exposed in Let's Encrypt's
directory: https://acme-v01.api.letsencrypt.org/directory

This was fixed in version 0.6.0 of the acme library
(https://github.com/certbot/certbot/pull/2963), so we can use that
(there are barely any other changes between the version we're currently
using - 0.5.0 - and this one).

---

cc @fancyremarker @blakepettersson 